### PR TITLE
Say hello

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,13 +30,26 @@ COPY config/ ./config/
 # Compilar aplicación
 RUN npm run build
 
-# Stage de producción - imagen mínima
+# Stage de producción - imagen mínima con Chromium
 FROM node:18-alpine AS runner
 WORKDIR /app
 
 # Variables de entorno para producción (Railway setea PORT dinámicamente)
 ENV NODE_ENV=production \
-    NODE_OPTIONS="--max-old-space-size=768"
+    NODE_OPTIONS="--max-old-space-size=768" \
+    PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true \
+    PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
+
+# Instalar Chromium y dependencias necesarias para Puppeteer
+RUN apk add --no-cache \
+    chromium \
+    nss \
+    freetype \
+    freetype-dev \
+    harfbuzz \
+    ca-certificates \
+    ttf-freefont \
+    && rm -rf /var/cache/apk/*
 
 # Crear usuario no-root
 RUN addgroup -g 1001 -S nodejs && \

--- a/docs/deployment/CHROMIUM_RAILWAY_FIX.md
+++ b/docs/deployment/CHROMIUM_RAILWAY_FIX.md
@@ -1,0 +1,129 @@
+# Solución para Chromium/Puppeteer en Railway
+
+## Problema Identificado
+
+El bot falla al generar PDFs en Railway con el siguiente error:
+```
+Error: Tried to find the browser at the configured path (/usr/bin/chromium), but no executable was found.
+```
+
+## Causa del Problema
+
+1. **Imagen Docker Alpine**: La imagen `node:18-alpine` no incluye Chromium
+2. **Puppeteer requiere Chromium**: Para generar PDFs, Puppeteer necesita un navegador instalado
+3. **Railway/Nixpacks**: Railway usa Nixpacks que requiere configuración especial
+
+## Solución Implementada
+
+### 1. Dockerfile Actualizado
+Se modificó el Dockerfile para instalar Chromium y sus dependencias:
+
+```dockerfile
+# Instalar Chromium y dependencias
+RUN apk add --no-cache \
+    chromium \
+    nss \
+    freetype \
+    freetype-dev \
+    harfbuzz \
+    ca-certificates \
+    ttf-freefont
+```
+
+### 2. Configuración de Nixpacks
+Se creó `nixpacks.toml` para Railway:
+- Instala Chromium y todas las librerías necesarias
+- Configura variables de entorno para Puppeteer
+- Define el path correcto de Chromium
+
+### 3. Configuración de Puppeteer
+Se creó `src/config/puppeteer.config.ts`:
+- Detecta automáticamente el entorno (Railway, Docker, local)
+- Configura el path correcto de Chromium según el entorno
+- Incluye reintentos y fallbacks
+
+### 4. Dependencias Agregadas
+Se agregaron a `package.json`:
+- `puppeteer`: Para desarrollo local
+- `puppeteer-core`: Para producción (usa Chromium del sistema)
+
+## Pasos para Desplegar
+
+1. **Instalar dependencias localmente**:
+   ```bash
+   npm install
+   ```
+
+2. **Construir el proyecto**:
+   ```bash
+   npm run build
+   ```
+
+3. **Desplegar a Railway**:
+   ```bash
+   git add .
+   git commit -m "fix: agregar soporte para Chromium en Railway para generación de PDFs"
+   git push origin main
+   ```
+
+## Configuración en Railway
+
+Railway debería detectar automáticamente el archivo `nixpacks.toml` y:
+1. Instalar Chromium del sistema
+2. Configurar las variables de entorno necesarias
+3. Usar la configuración correcta de Puppeteer
+
+## Variables de Entorno
+
+Asegúrate de que estas variables estén configuradas en Railway:
+
+```env
+PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+PUPPETEER_EXECUTABLE_PATH=/nix/store/*/bin/chromium
+NODE_OPTIONS=--max-old-space-size=768
+```
+
+## Verificación
+
+Para verificar que funciona:
+
+1. **Logs de inicio**: Deberías ver:
+   ```
+   🔧 Puppeteer configurado para entorno: railway
+   📍 Usando Chromium en: /nix/store/*/bin/chromium
+   ```
+
+2. **Generación de PDF**: La función `generate_booking_confirmation_pdf` debería completarse sin errores
+
+## Troubleshooting
+
+Si continúa fallando:
+
+1. **Verificar logs de Railway**:
+   ```bash
+   npm run logs:railway:live
+   ```
+
+2. **Probar configuración alternativa**: 
+   Si nixpacks falla, puedes usar solo el Dockerfile con:
+   ```
+   railway up --build
+   ```
+
+3. **Verificar memoria**: 
+   Railway tiene límites de memoria. Si el bot se queda sin memoria al lanzar Chromium, considera:
+   - Aumentar el plan de Railway
+   - Optimizar el uso de memoria con `--single-process` en los args de Puppeteer
+
+## Notas Importantes
+
+- **Desarrollo local**: En local, Puppeteer descarga su propio Chromium
+- **Railway**: Usa el Chromium del sistema instalado por nixpacks
+- **Docker**: Usa chromium-browser de Alpine
+- **Memoria**: La generación de PDFs consume ~100-200MB adicionales de RAM
+
+## Referencias
+
+- [Puppeteer Troubleshooting](https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md)
+- [Railway Nixpacks Documentation](https://nixpacks.com/docs)
+- [Alpine Chromium Package](https://pkgs.alpinelinux.org/package/edge/community/x86/chromium)

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,0 +1,24 @@
+# Configuración de Nixpacks para Railway
+# Este archivo configura el entorno de Railway para soportar Puppeteer y Chromium
+
+[phases.setup]
+# Instalar paquetes del sistema necesarios
+nixPkgs = ["nodejs-18_x", "chromium", "glib", "nss", "nspr", "atk", "at-spi2-atk", "cups", "drm", "dbus", "expat", "libxcb", "libxkbcommon", "x11", "xorg.libX11", "xorg.libXcomposite", "xorg.libXdamage", "xorg.libXext", "xorg.libXfixes", "xorg.libXrandr", "xorg.libxcb", "cairo", "pango", "alsa-lib"]
+
+[phases.install]
+# Instalar dependencias de Node.js
+cmds = ["npm ci --only=production"]
+
+[phases.build]
+# Compilar la aplicación TypeScript
+cmds = ["npm run build"]
+
+[start]
+# Comando de inicio con variables de entorno para Puppeteer
+cmd = "node dist/app-unified.js"
+
+[variables]
+# Variables de entorno para Puppeteer
+PUPPETEER_SKIP_CHROMIUM_DOWNLOAD = "true"
+PUPPETEER_EXECUTABLE_PATH = "/nix/store/*/bin/chromium"
+NODE_OPTIONS = "--max-old-space-size=768"

--- a/package.json
+++ b/package.json
@@ -68,6 +68,8 @@
     "node-fetch": "^3.3.2",
     "openai": "^4.76.0",
     "prom-client": "^15.1.3",
+    "puppeteer": "^23.11.0",
+    "puppeteer-core": "^23.11.0",
     "tslib": "^2.8.1"
   },
   "devDependencies": {

--- a/src/config/puppeteer.config.ts
+++ b/src/config/puppeteer.config.ts
@@ -1,0 +1,168 @@
+/**
+ * Configuración de Puppeteer para diferentes entornos
+ * Maneja las rutas de Chromium para local, Railway y otros entornos cloud
+ */
+
+export interface PuppeteerConfig {
+  executablePath?: string;
+  headless: boolean | 'shell';
+  args: string[];
+  ignoreDefaultArgs?: string[];
+  handleSIGINT: boolean;
+  handleSIGTERM: boolean;
+  handleSIGHUP: boolean;
+  dumpio: boolean;
+  timeout: number;
+}
+
+/**
+ * Detecta el entorno de ejecución
+ */
+function detectEnvironment(): 'railway' | 'local' | 'docker' | 'unknown' {
+  // Railway setea esta variable
+  if (process.env.RAILWAY_ENVIRONMENT) {
+    return 'railway';
+  }
+  
+  // Detectar si estamos en Docker
+  if (process.env.DOCKER_CONTAINER || process.env.NODE_ENV === 'production') {
+    return 'docker';
+  }
+  
+  // Por defecto asumimos local
+  return process.env.NODE_ENV === 'development' ? 'local' : 'unknown';
+}
+
+/**
+ * Obtiene la ruta del ejecutable de Chromium según el entorno
+ */
+function getChromiumPath(): string | undefined {
+  const environment = detectEnvironment();
+  
+  switch (environment) {
+    case 'railway':
+      // En Railway con nixpacks
+      return process.env.PUPPETEER_EXECUTABLE_PATH || '/nix/store/*/bin/chromium';
+      
+    case 'docker':
+      // En Docker Alpine
+      return '/usr/bin/chromium-browser';
+      
+    case 'local':
+      // En desarrollo local, dejar que Puppeteer use su Chromium descargado
+      return undefined;
+      
+    default:
+      // Intentar detectar automáticamente
+      const possiblePaths = [
+        '/usr/bin/chromium-browser', // Alpine
+        '/usr/bin/chromium',          // Debian/Ubuntu
+        '/usr/bin/google-chrome',     // Google Chrome
+      ];
+      
+      // Buscar el primer path que exista
+      const fs = require('fs');
+      for (const path of possiblePaths) {
+        if (fs.existsSync(path)) {
+          return path;
+        }
+      }
+      
+      return undefined;
+  }
+}
+
+/**
+ * Configuración de Puppeteer optimizada para el entorno actual
+ */
+export function getPuppeteerConfig(): PuppeteerConfig {
+  const environment = detectEnvironment();
+  const isProduction = process.env.NODE_ENV === 'production';
+  
+  console.log(`🔧 Puppeteer configurado para entorno: ${environment}`);
+  
+  const baseConfig: PuppeteerConfig = {
+    headless: isProduction ? true : 'shell',
+    args: [
+      '--no-sandbox',
+      '--disable-setuid-sandbox',
+      '--disable-dev-shm-usage',
+      '--disable-accelerated-2d-canvas',
+      '--disable-gpu',
+      '--no-first-run',
+      '--no-zygote',
+      '--single-process', // Importante para contenedores
+      '--disable-extensions',
+      '--disable-background-timer-throttling',
+      '--disable-backgrounding-occluded-windows',
+      '--disable-renderer-backgrounding',
+    ],
+    ignoreDefaultArgs: ['--disable-extensions'],
+    handleSIGINT: false,
+    handleSIGTERM: false,
+    handleSIGHUP: false,
+    dumpio: !isProduction, // Solo logs en desarrollo
+    timeout: 60000,
+  };
+  
+  // Agregar ruta del ejecutable si está disponible
+  const chromiumPath = getChromiumPath();
+  if (chromiumPath) {
+    baseConfig.executablePath = chromiumPath;
+    console.log(`📍 Usando Chromium en: ${chromiumPath}`);
+  } else {
+    console.log('📦 Usando Chromium empaquetado con Puppeteer');
+  }
+  
+  // Configuraciones específicas por entorno
+  if (environment === 'railway') {
+    // Railway tiene limitaciones de memoria
+    baseConfig.args.push('--max-old-space-size=512');
+    baseConfig.args.push('--memory-pressure-off');
+  }
+  
+  return baseConfig;
+}
+
+/**
+ * Configuración para lanzar Puppeteer con reintentos
+ */
+export async function launchPuppeteerWithRetry(
+  puppeteer: any,
+  maxRetries: number = 3
+): Promise<any> {
+  const config = getPuppeteerConfig();
+  let lastError: Error | null = null;
+  
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    try {
+      console.log(`🚀 Intento ${attempt} de lanzar Puppeteer...`);
+      const browser = await puppeteer.launch(config);
+      console.log('✅ Puppeteer lanzado exitosamente');
+      return browser;
+    } catch (error: any) {
+      lastError = error;
+      console.error(`❌ Intento ${attempt} falló:`, error.message);
+      
+      if (attempt < maxRetries) {
+        // Esperar antes de reintentar
+        await new Promise(resolve => setTimeout(resolve, 1000 * attempt));
+        
+        // En el segundo intento, probar sin ruta específica
+        if (attempt === 2 && config.executablePath) {
+          delete config.executablePath;
+          console.log('🔄 Intentando con Chromium empaquetado...');
+        }
+      }
+    }
+  }
+  
+  throw new Error(`No se pudo lanzar Puppeteer después de ${maxRetries} intentos: ${lastError?.message}`);
+}
+
+// Exportar configuración por defecto
+export default {
+  getPuppeteerConfig,
+  launchPuppeteerWithRetry,
+  detectEnvironment,
+};


### PR DESCRIPTION
Add Chromium support to Railway to fix Puppeteer PDF generation failures.

The existing Dockerfile used an Alpine Node.js image which does not include Chromium, leading to Puppeteer failing to find the browser executable. This PR installs Chromium and configures Puppeteer for Railway, Docker, and local environments.

---
<a href="https://cursor.com/background-agent?bcId=bc-f65f0236-c5b8-42b1-beb5-2e7bf1605163">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f65f0236-c5b8-42b1-beb5-2e7bf1605163">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

